### PR TITLE
Switch to using vendorHash for go builds

### DIFF
--- a/packages/omc.nix
+++ b/packages/omc.nix
@@ -29,7 +29,7 @@ rec {
         repo = "omc";
         sha256 = "${sha256}";
       };
-      vendorSha256 = null;
+      vendorHash = null;
 
       doCheck = false;
       preBuild = ''

--- a/packages/opc.nix
+++ b/packages/opc.nix
@@ -17,7 +17,7 @@ rec {
         repo = "opc";
         sha256 = "${sha256}";
       };
-      vendorSha256 = null;
+      vendorHash = null;
 
       patchPhase = ''
         sed -i 's/devel/${version}/' ./pkg/version.json

--- a/packages/operator-sdk.nix
+++ b/packages/operator-sdk.nix
@@ -6,11 +6,11 @@ rec {
     { version
     , k8sVersion
     , sha256
-    , vendorSha256
+    , vendorHash
     }:
 
     buildGo119Module rec {
-      inherit vendorSha256;
+      inherit vendorHash;
       pname = "operator-sdk";
       name = "${pname}-${version}";
       rev = "v${version}";
@@ -36,7 +36,7 @@ rec {
         repo = "operator-sdk";
         sha256 = "${sha256}";
       };
-      modSha256 = "${vendorSha256}";
+      modSha256 = "${vendorHash}";
 
       postInstall = ''
         # completions
@@ -57,67 +57,67 @@ rec {
     version = "1.22.2";
     k8sVersion = "1.24";
     sha256 = "sha256-SpSdVJeN+rOZ6jeFPKadXKQLBZmrLjbrBrJsK9zDiZg=";
-    vendorSha256 = "sha256-MiA3XbdSwzZLilvrqlNU8e2nMAfhmVnNeG1oUx4ISRU=";
+    vendorHash = "sha256-MiA3XbdSwzZLilvrqlNU8e2nMAfhmVnNeG1oUx4ISRU=";
   };
   operator-sdk_1_23 = makeOverridable operatorSdkGen {
     version = "1.23.0";
     k8sVersion = "1.24";
     sha256 = "sha256-2/zXdhRp8Q7e9ty0Zp+fpmcLNW6qfrW6ND83sypx9Xw=";
-    vendorSha256 = "sha256-3/kU+M+oKaPJkqMNuvd1ANlHRnXhaUrofj/rl3CS5Ao=";
+    vendorHash = "sha256-3/kU+M+oKaPJkqMNuvd1ANlHRnXhaUrofj/rl3CS5Ao=";
   };
   operator-sdk_1_24 = makeOverridable operatorSdkGen {
     version = "1.24.1";
     k8sVersion = "1.24";
     sha256 = "sha256-6Al9EkAnaa7/wJzV4xy6FifPXa4MdA9INwJWpkWzCb8=";
-    vendorSha256 = "sha256-eczTVlArpO+uLC6IsTkj4LBIi+fXq7CMBf1zJShDN58=";
+    vendorHash = "sha256-eczTVlArpO+uLC6IsTkj4LBIi+fXq7CMBf1zJShDN58=";
   };
   operator-sdk_1_25 = makeOverridable operatorSdkGen {
     version = "1.25.4";
     k8sVersion = "1.25";
     sha256 = "sha256-uLWGE/FL4sfcFz9caVMgdFGzH8jsuFIXNAT8PdhqUio=";
-    vendorSha256 = "sha256-L+Z1k+z/XNO9OeTQVzNJd1caRip6Ti8mPfNmXJx5D5c=";
+    vendorHash = "sha256-L+Z1k+z/XNO9OeTQVzNJd1caRip6Ti8mPfNmXJx5D5c=";
   };
   operator-sdk_1_26 = makeOverridable operatorSdkGen {
     version = "1.26.1";
     k8sVersion = "1.25";
     sha256 = "sha256-D82tFN0EUmcRUkXf8kSaxzVacS+Ggwa+8D5f8ZSvVy0=";
-    vendorSha256 = "sha256-L+Z1k+z/XNO9OeTQVzNJd1caRip6Ti8mPfNmXJx5D5c=";
+    vendorHash = "sha256-L+Z1k+z/XNO9OeTQVzNJd1caRip6Ti8mPfNmXJx5D5c=";
   };
   operator-sdk_1_27 = makeOverridable operatorSdkGen {
     version = "1.27.0";
     k8sVersion = "1.25";
     sha256 = "sha256-rvLWM6G2kOOuFU0JuwdIjSCFNyjBNL+fOoEj+tIR190=";
-    vendorSha256 = "sha256-L+Z1k+z/XNO9OeTQVzNJd1caRip6Ti8mPfNmXJx5D5c=";
+    vendorHash = "sha256-L+Z1k+z/XNO9OeTQVzNJd1caRip6Ti8mPfNmXJx5D5c=";
   };
   operator-sdk_1_28 = makeOverridable operatorSdkGen {
     version = "1.28.1";
     k8sVersion = "1.26";
     sha256 = "sha256-YzkPAKwkV8io0lz7JxIX4lciv85iqldkyitrLicbFJc=";
-    vendorSha256 = "sha256-ZWOIF3vmtoXzdGHHzjPy/351bHzMTTXcgSRBso+ixyM=";
+    vendorHash = "sha256-ZWOIF3vmtoXzdGHHzjPy/351bHzMTTXcgSRBso+ixyM=";
   };
   operator-sdk_1_29 = makeOverridable operatorSdkGen {
     version = "1.29.0";
     k8sVersion = "1.26";
     sha256 = "sha256-oHGs1Bx5k02k6mp9WAe8wIQ4FjMOREcUYv0DKZaXGdE==";
-    vendorSha256 = "sha256-I2vL4uRmUbgaf3KGUHSQV2jWozStKHyjek3BQlxyY/c=";
+    vendorHash = "sha256-I2vL4uRmUbgaf3KGUHSQV2jWozStKHyjek3BQlxyY/c=";
   };
   operator-sdk_1_30 = makeOverridable operatorSdkGen {
     version = "1.30.0";
     k8sVersion = "1.26";
     sha256 = "sha256-mDjBu25hOhm3FrUDsFq1rjBn58K91Bao8gqN2heZ9ps=";
-    vendorSha256 = "sha256-QfTWjSsWpbbGgKrv4U2E6jA6eAT4wnj0ixpUqDxtsY8=";
+    vendorHash = "sha256-QfTWjSsWpbbGgKrv4U2E6jA6eAT4wnj0ixpUqDxtsY8=";
   };
   operator-sdk_1_31 = makeOverridable operatorSdkGen {
     version = "1.31.0";
     k8sVersion = "1.26";
     sha256 = "sha256-v/7nqZg/lwiK2k92kQWSZCSjEZhTAQHCGBcTfxQX2r0=";
-    vendorSha256 = "sha256-geKWTsDLx5drTleTnneg2JIbe5sMS5JUQxTX9Bcm+IQ=";
+    vendorHash = "sha256-geKWTsDLx5drTleTnneg2JIbe5sMS5JUQxTX9Bcm+IQ=";
   };
   operator-sdk_1_32 = makeOverridable operatorSdkGen {
     version = "1.32.0";
     k8sVersion = "1.26";
     sha256 = "sha256-sWnHx9IKwr6um9YlrF2ULQ7HZo0TNC4MpWHTVpmWqFs=";
-    vendorSha256 = "sha256-Gl0LUlMLeku2B5DkWpzeoXfMLb/OnOx4Urw4RF4cuTQ=";
+    vendorHash = "sha256-Gl0LUlMLeku2B5DkWpzeoXfMLb/OnOx4Urw4RF4cuTQ=";
   };
   operator-sdk_1 = operator-sdk_1_32;
   operator-sdk = operator-sdk_1;

--- a/packages/opm.nix
+++ b/packages/opm.nix
@@ -5,11 +5,11 @@ rec {
   opmGen =
     { version
     , sha256
-    , vendorSha256
+    , vendorHash
     }:
 
     buildGoModule rec {
-      inherit vendorSha256;
+      inherit vendorHash;
       pname = "opm";
       name = "${pname}-${version}";
       rev = "v${version}";
@@ -54,32 +54,32 @@ rec {
   opm_1_31 = makeOverridable opmGen {
     version = "1.31.0";
     sha256 = "sha256-xb+zC4/gcF7rS6J6YN/L4kyD6RjsYT/FwxviyOMoLDs=";
-    vendorSha256 = "sha256-OfW+pSyYlRMkBYa3Hle58jFWwlWRFPfr1sYzwu0RQow=";
+    vendorHash = "sha256-OfW+pSyYlRMkBYa3Hle58jFWwlWRFPfr1sYzwu0RQow=";
   };
   opm_1_30 = makeOverridable opmGen {
     version = "1.30.1";
     sha256 = "sha256-2uSfIAIaIeb2DACWaueVjvTiuumzDUqLmVXi34Pj1iM=";
-    vendorSha256 = "sha256-5R+gFjgFchcCSxGij0KvpSUOVsfgOY/M3PW9Npv0obg=";
+    vendorHash = "sha256-5R+gFjgFchcCSxGij0KvpSUOVsfgOY/M3PW9Npv0obg=";
   };
   opm_1_29 = makeOverridable opmGen {
     version = "1.29.0";
     sha256 = "sha256-mIZ0M+q7lF44wiXasZvrYBtk/eFbbE7h3eRLKE9AF58=";
-    vendorSha256 = "sha256-HSmjr3l0Zat0bLuCUrbfqg+Jo6uLbjH/dH5rPzxg/KA=";
+    vendorHash = "sha256-HSmjr3l0Zat0bLuCUrbfqg+Jo6uLbjH/dH5rPzxg/KA=";
   };
   opm_1_28 = makeOverridable opmGen {
     version = "1.28.0";
     sha256 = "sha256-ctSoAR6qLqAtXOd32tmCLOQdvwNNItJtlpqvNvxrY1w=";
-    vendorSha256 = "sha256-P7H+3pfzbmRKKS990JDWab0waCIA88ZtfdtgYFHlR08=";
+    vendorHash = "sha256-P7H+3pfzbmRKKS990JDWab0waCIA88ZtfdtgYFHlR08=";
   };
   opm_1_27 = makeOverridable opmGen {
     version = "1.27.1";
     sha256 = "sha256-EvtF0E7j6br4D5Z+0vOYU9CNyCgmZ8aq028SbSKOI+s=";
-    vendorSha256 = "sha256-bK1jkwwUiXQysRcsxLj78I2Zey+5IPygMPV3SOgcbzU=";
+    vendorHash = "sha256-bK1jkwwUiXQysRcsxLj78I2Zey+5IPygMPV3SOgcbzU=";
   };
   opm_1_26 = makeOverridable opmGen {
     version = "1.26.5";
     sha256 = "sha256-pTwb+ywisK+4+Z18CnJVSd6JoQyqyW9iIf8Wi6TAg4k=";
-    vendorSha256 = null;
+    vendorHash = null;
   };
   opm = opm_1_31;
 }


### PR DESCRIPTION
`vendorSha256` are deprecated now.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
