### PR TITLE
omc: use go 1.21 to build it.

### DIFF
--- a/packages/omc.nix
+++ b/packages/omc.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGo119Module, fetchFromGitHub }:
+{ stdenv, lib, buildGo121Module, fetchFromGitHub }:
 
 with lib;
 rec {
@@ -7,7 +7,7 @@ rec {
     , sha256
     , rev ? "v${version}"
     }:
-    buildGo119Module rec {
+    buildGo121Module rec {
       pname = "omc";
       name = "${pname}-${version}";
 


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>
