### PR TITLE
packages/opc: use go 1.22 from now on

### DIFF
--- a/packages/opc.nix
+++ b/packages/opc.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGo121Module, fetchFromGitHub }:
+{ stdenv, lib, buildGo122Module, fetchFromGitHub }:
 
 with lib;
 rec {
@@ -7,7 +7,7 @@ rec {
     , sha256
     , rev ? "v${version}"
     }:
-    buildGo121Module rec {
+    buildGo122Module rec {
       pname = "opc";
       name = "${pname}-${version}";
 


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>
