### PR TITLE
update-packages: skip versioned packages derived from repos JSON

### DIFF
--- a/update-packages
+++ b/update-packages
@@ -61,6 +61,16 @@ is_git_package() {
         return 0
     fi
 
+    # Check if package is a versioned variant (e.g., oc_4_14, openshift-install_4_15)
+    # These are derived from repos JSON and should be skipped
+    for git_pkg in "${git_packages[@]}"; do
+        # Replace hyphens with underscores for matching (openshift-install -> openshift_install)
+        local normalized_git_pkg="${git_pkg//-/_}"
+        if [[ "$package" == "${normalized_git_pkg}_"[0-9]* ]]; then
+            return 0
+        fi
+    done
+
     # Check if the package's nix file imports any git-tracked repo JSON
     local pkg_file="packages/${package}.nix"
     if [ -f "$pkg_file" ]; then
@@ -82,7 +92,10 @@ update_with_nix_update() {
     local package=$1
     info "Updating $package with nix-update..."
 
-    if nix-update --flake --commit --use-update-script "$package"; then
+    # Note: --use-update-script is not used here because none of the packages
+    # in this flake define passthru.updateScript. If packages with custom
+    # update scripts are added, this should be made conditional.
+    if nix-update --flake --commit "$package"; then
         info "Successfully updated $package"
         return 0
     else


### PR DESCRIPTION
## Summary
Fix the update-packages workflow failures:

### 1. Skip versioned packages derived from repos JSON
Versioned package variants like `oc_4_14` and `openshift-install_4_15` are dynamically generated from `repos/oc.json` and `repos/openshift-install.json`. They don't have individual nix files, so the previous check for JSON imports didn't catch them.

The fix normalizes package names (replacing hyphens with underscores) and checks if they match the pattern `<base_package>_<version>`.

### 2. Remove `--use-update-script` flag
This flag was ported from chick-group where it's needed for packages with custom `passthru.updateScript` (like `pi-coding-agent`). However, no packages in chapeau-rouge define update scripts.

The flag was causing failures for python packages (`did`, `lumino-mcp-server`) as nix-update tried to run non-existent update scripts, resulting in "expected a set but found null" errors.

## Test plan
- [ ] Verify update-packages workflow no longer attempts to update `oc_4_*` and `openshift-install_4_*` packages with nix-update
- [ ] Verify `did` and `lumino-mcp-server` packages update without errors

🤖 Generated with [Claude Code](https://claude.ai/code)