### PR TITLE
update-packages: clarify version pattern matching

### DIFF
--- a/update-packages
+++ b/update-packages
@@ -66,6 +66,8 @@ is_git_package() {
     for git_pkg in "${git_packages[@]}"; do
         # Replace hyphens with underscores for matching (openshift-install -> openshift_install)
         local normalized_git_pkg="${git_pkg//-/_}"
+        # Pattern: [0-9]* in bash globs means "one digit followed by anything"
+        # (not "zero or more digits" as in regex). This correctly matches oc_4_14, etc.
         if [[ "$package" == "${normalized_git_pkg}_"[0-9]* ]]; then
             return 0
         fi


### PR DESCRIPTION
## Summary
Addresses the review comment from gemini-code-assist on PR #299.

The comment suggested using `[0-9]+` instead of `[0-9]*`, but this is based on regex syntax, not bash glob syntax. In bash globs:
- `[0-9]` matches exactly **one** digit
- `*` matches zero or more of **any** character

So `[0-9]*` actually means "one digit followed by anything", which is correct for matching versioned packages like `oc_4_14`.

Added a clarifying comment to explain this difference between bash globs and regex.

## Test plan
- [x] Pattern behavior unchanged - still correctly matches `oc_4_14`, `openshift_install_4_15`, etc.

🤖 Generated with [Claude Code](https://claude.ai/code)